### PR TITLE
Added ppm output

### DIFF
--- a/cmake/Modules/FindFFTW.cmake
+++ b/cmake/Modules/FindFFTW.cmake
@@ -21,6 +21,7 @@ FIND_LIBRARY(FFTW_LIBRARY
   PATHS ${FFTW_DIR}/libs
   "${FFTW_DIR}\\win32\\lib"
   /usr/lib/x86_64-linux-gnu
+  /usr/lib/i386-linux-gnu
   /usr/pkgs64/lib
   /usr/lib64
   /usr/lib

--- a/cmake/Modules/FindFFTW.cmake
+++ b/cmake/Modules/FindFFTW.cmake
@@ -20,6 +20,7 @@ FIND_LIBRARY(FFTW_LIBRARY
   NAMES fftw3
   PATHS ${FFTW_DIR}/libs
   "${FFTW_DIR}\\win32\\lib"
+  /usr/lib/arm-linux-gnueabihf
   /usr/lib/x86_64-linux-gnu
   /usr/lib/i386-linux-gnu
   /usr/pkgs64/lib

--- a/cmake/Modules/FindITPP.cmake
+++ b/cmake/Modules/FindITPP.cmake
@@ -24,6 +24,7 @@ FIND_LIBRARY(ITPP_LIBRARY_NORMAL
   /usr/lib64
   /usr/lib
   /usr/local/lib
+  /usr/lib/arm-linux-gnueabihf  
   NO_DEFAULT_PATH
 )
 
@@ -35,6 +36,7 @@ FIND_LIBRARY(ITPP_LIBRARY_DEBUG
   /usr/lib64
   /usr/lib
   /usr/local/lib
+  /usr/lib/arm-linux-gnueabihf  
   NO_DEFAULT_PATH
 )
 

--- a/src/CellSearch.cpp
+++ b/src/CellSearch.cpp
@@ -578,7 +578,7 @@ int main(
   } else {
     cout << "Detected the following cells:" << endl;
     cout << "A: #antenna ports C: CP type ; P: PHICH duration ; PR: PHICH resource type" << endl;
-    cout << "CID A      fc   foff RXPWR C nRB P  PR CrystalCorrectionFactor" << endl;
+    cout << "CID A      fc   foff RXPWR C nRB P  PR CrystalCorrection  ppm" << endl;
     list <Cell>::iterator it=cells_final.begin();
     while (it!=cells_final.end()) {
       // Use a stringstream to avoid polluting the iostream settings of cout.
@@ -606,7 +606,10 @@ int main(
       // Calculate correction factors
       const double correction_residual=true_location/crystal_freq_actual;
       const double correction_new=correction*correction_residual;
-      ss << " " << setprecision(20) << correction_new;
+      ss << " " << setw(17) << setprecision(15) << correction_new;
+      // Calculate deviation in ppm
+      const double correction_ppm=1e6*(correction_new-1);
+      ss << " " << setw(5) << setprecision(3) << correction_ppm;
       cout << ss.str() << endl;
 
       ++it;


### PR DESCRIPTION
Added ppm output for easy usage in other applications like SDR#.

In SDR# you need to change the sign of the ppm of course because this show the DEVIATION and not the CORRECTION.
